### PR TITLE
Implement Projects API endpoints

### DIFF
--- a/app-service/build.gradle
+++ b/app-service/build.gradle
@@ -1,4 +1,8 @@
 dependencies {
+    implementation project(':api-first')
+    implementation project(':application')
+    implementation project(':domain')
+    implementation project(':infrastructure')
 }
 
 tasks.register('explodedJar', Copy) {

--- a/app-service/src/main/java/co/com/nelumbo/backpmo/controller/ProjectController.java
+++ b/app-service/src/main/java/co/com/nelumbo/backpmo/controller/ProjectController.java
@@ -1,0 +1,64 @@
+package co.com.nelumbo.backpmo.controller;
+
+import co.com.nelumbo.backpmo.apifirst.openapi.api.ProjectsApi;
+import co.com.nelumbo.backpmo.apifirst.openapi.model.NewProjectDto;
+import co.com.nelumbo.backpmo.apifirst.openapi.model.ProjectDto;
+import co.com.nelumbo.backpmo.application.service.ProjectService;
+import co.com.nelumbo.backpmo.domain.model.Project;
+import co.com.nelumbo.backpmo.domain.model.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+public class ProjectController implements ProjectsApi {
+
+    private final ProjectService service;
+
+    public ProjectController(ProjectService service) {
+        this.service = service;
+    }
+
+    @Override
+    public ResponseEntity<ProjectDto> createProject(NewProjectDto newProjectDto) {
+        Project project = fromDto(newProjectDto);
+        Project saved = service.create(project);
+        return new ResponseEntity<>(toDto(saved), HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<ProjectDto> getProjectById(Integer projectId) {
+        return service.findById(projectId)
+                .map(p -> ResponseEntity.ok(toDto(p)))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @Override
+    public ResponseEntity<List<ProjectDto>> getProjects() {
+        List<ProjectDto> list = service.list().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(list);
+    }
+
+    private ProjectDto toDto(Project project) {
+        ProjectDto dto = new ProjectDto(project.getId(), project.getName(), ProjectDto.StatusEnum.valueOf(project.getStatus().name()));
+        dto.setDescription(project.getDescription());
+        dto.setStartDate(project.getStartDate());
+        dto.setEndDate(project.getEndDate());
+        return dto;
+    }
+
+    private Project fromDto(NewProjectDto dto) {
+        Project project = new Project();
+        project.setName(dto.getName());
+        project.setDescription(dto.getDescription());
+        project.setStartDate(dto.getStartDate());
+        project.setEndDate(dto.getEndDate());
+        project.setStatus(Status.valueOf(dto.getStatus().name()));
+        return project;
+    }
+}

--- a/app-service/src/main/resources/application.properties
+++ b/app-service/src/main/resources/application.properties
@@ -1,1 +1,6 @@
 spring.application.name=backpmo
+spring.datasource.url=jdbc:postgresql://localhost:5432/backpmo
+spring.datasource.username=user
+spring.datasource.password=pass
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    implementation project(':domain')
+    implementation libs.jpa
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/application/src/main/java/co/com/nelumbo/backpmo/application/service/ProjectService.java
+++ b/application/src/main/java/co/com/nelumbo/backpmo/application/service/ProjectService.java
@@ -1,0 +1,11 @@
+package co.com.nelumbo.backpmo.application.service;
+
+import co.com.nelumbo.backpmo.domain.model.Project;
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectService {
+    Project create(Project project);
+    List<Project> list();
+    Optional<Project> findById(Integer id);
+}

--- a/application/src/main/java/co/com/nelumbo/backpmo/application/service/ProjectServiceImpl.java
+++ b/application/src/main/java/co/com/nelumbo/backpmo/application/service/ProjectServiceImpl.java
@@ -1,0 +1,35 @@
+package co.com.nelumbo.backpmo.application.service;
+
+import co.com.nelumbo.backpmo.domain.model.Project;
+import co.com.nelumbo.backpmo.domain.ports.ProjectRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class ProjectServiceImpl implements ProjectService {
+
+    private final ProjectRepository repository;
+
+    public ProjectServiceImpl(ProjectRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Project create(Project project) {
+        return repository.save(project);
+    }
+
+    @Override
+    public List<Project> list() {
+        return repository.findAll();
+    }
+
+    @Override
+    public Optional<Project> findById(Integer id) {
+        return repository.findById(id);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: backpmo
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+    ports:
+      - "5432:5432"
+

--- a/domain/src/main/java/co/com/nelumbo/backpmo/domain/model/Project.java
+++ b/domain/src/main/java/co/com/nelumbo/backpmo/domain/model/Project.java
@@ -1,0 +1,72 @@
+package co.com.nelumbo.backpmo.domain.model;
+
+import java.time.LocalDate;
+
+public class Project {
+    private Integer id;
+    private String name;
+    private String description;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Status status;
+
+    public Project() {
+    }
+
+    public Project(Integer id, String name, String description, LocalDate startDate, LocalDate endDate, Status status) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/domain/src/main/java/co/com/nelumbo/backpmo/domain/model/Status.java
+++ b/domain/src/main/java/co/com/nelumbo/backpmo/domain/model/Status.java
@@ -1,0 +1,7 @@
+package co.com.nelumbo.backpmo.domain.model;
+
+public enum Status {
+    PLANNED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/domain/src/main/java/co/com/nelumbo/backpmo/domain/ports/ProjectRepository.java
+++ b/domain/src/main/java/co/com/nelumbo/backpmo/domain/ports/ProjectRepository.java
@@ -1,0 +1,11 @@
+package co.com.nelumbo.backpmo.domain.ports;
+
+import co.com.nelumbo.backpmo.domain.model.Project;
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectRepository {
+    Project save(Project project);
+    List<Project> findAll();
+    Optional<Project> findById(Integer id);
+}

--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -10,6 +10,10 @@ repositories {
 }
 
 dependencies {
+    implementation project(':domain')
+    implementation libs.jpa
+    runtimeOnly 'org.postgresql:postgresql:42.7.3'
+    testImplementation libs.h2Database
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/adapter/ProjectRepositoryAdapter.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/adapter/ProjectRepositoryAdapter.java
@@ -1,0 +1,63 @@
+package co.com.nelumbo.backpmo.infrastructure.adapter;
+
+import co.com.nelumbo.backpmo.domain.model.Project;
+import co.com.nelumbo.backpmo.domain.model.Status;
+import co.com.nelumbo.backpmo.domain.ports.ProjectRepository;
+import co.com.nelumbo.backpmo.infrastructure.entity.ProjectEntity;
+import co.com.nelumbo.backpmo.infrastructure.repository.SpringProjectRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+public class ProjectRepositoryAdapter implements ProjectRepository {
+
+    private final SpringProjectRepository repository;
+
+    public ProjectRepositoryAdapter(SpringProjectRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Project save(Project project) {
+        ProjectEntity entity = toEntity(project);
+        ProjectEntity saved = repository.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    public List<Project> findAll() {
+        return repository.findAll().stream()
+                .map(this::toDomain)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Project> findById(Integer id) {
+        return repository.findById(id).map(this::toDomain);
+    }
+
+    private ProjectEntity toEntity(Project project) {
+        ProjectEntity entity = new ProjectEntity();
+        entity.setId(project.getId());
+        entity.setName(project.getName());
+        entity.setDescription(project.getDescription());
+        entity.setStartDate(project.getStartDate());
+        entity.setEndDate(project.getEndDate());
+        entity.setStatus(project.getStatus());
+        return entity;
+    }
+
+    private Project toDomain(ProjectEntity entity) {
+        return new Project(
+                entity.getId(),
+                entity.getName(),
+                entity.getDescription(),
+                entity.getStartDate(),
+                entity.getEndDate(),
+                entity.getStatus()
+        );
+    }
+}

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/entity/ProjectEntity.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/entity/ProjectEntity.java
@@ -1,0 +1,73 @@
+package co.com.nelumbo.backpmo.infrastructure.entity;
+
+import co.com.nelumbo.backpmo.domain.model.Status;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "projects")
+public class ProjectEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    private String description;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/repository/SpringProjectRepository.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/repository/SpringProjectRepository.java
@@ -1,0 +1,7 @@
+package co.com.nelumbo.backpmo.infrastructure.repository;
+
+import co.com.nelumbo.backpmo.infrastructure.entity.ProjectEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringProjectRepository extends JpaRepository<ProjectEntity, Integer> {
+}


### PR DESCRIPTION
## Summary
- add domain model and repository
- add application service
- implement JPA repository adapter
- implement controller based on OpenAPI
- configure datasource and docker-compose for PostgreSQL
- wire module dependencies

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_6867f597f21c832a8dc8e42341661046