### PR TITLE
Move ProjectController to infrastructure module

### DIFF
--- a/infrastructure/build.gradle
+++ b/infrastructure/build.gradle
@@ -11,6 +11,8 @@ repositories {
 
 dependencies {
     implementation project(':domain')
+    implementation project(':application')
+    implementation project(':api-first')
     implementation libs.jpa
     runtimeOnly 'org.postgresql:postgresql:42.7.3'
     testImplementation libs.h2Database

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/controller/ProjectController.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/controller/ProjectController.java
@@ -1,4 +1,4 @@
-package co.com.nelumbo.backpmo.controller;
+package co.com.nelumbo.backpmo.infrastructure.controller;
 
 import co.com.nelumbo.backpmo.apifirst.openapi.api.ProjectsApi;
 import co.com.nelumbo.backpmo.apifirst.openapi.model.NewProjectDto;


### PR DESCRIPTION
## Summary
- move `ProjectController` under infrastructure layer
- wire infrastructure module to application and API modules

## Testing
- `./gradlew test` *(fails: Execution failed for task ':app-service:test')*

------
https://chatgpt.com/codex/tasks/task_e_6867fca330d0832aa1988649f52f5ff3