### PR TITLE
Add global exception handling

### DIFF
--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/controller/ProjectController.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/controller/ProjectController.java
@@ -6,6 +6,7 @@ import co.com.nelumbo.backpmo.apifirst.openapi.model.ProjectDto;
 import co.com.nelumbo.backpmo.application.service.ProjectService;
 import co.com.nelumbo.backpmo.domain.model.Project;
 import co.com.nelumbo.backpmo.domain.model.Status;
+import co.com.nelumbo.backpmo.infrastructure.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,9 +32,9 @@ public class ProjectController implements ProjectsApi {
 
     @Override
     public ResponseEntity<ProjectDto> getProjectById(Integer projectId) {
-        return service.findById(projectId)
-                .map(p -> ResponseEntity.ok(toDto(p)))
-                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+        Project project = service.findById(projectId)
+                .orElseThrow(() -> new NotFoundException("Project not found with id " + projectId));
+        return ResponseEntity.ok(toDto(project));
     }
 
     @Override

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/exception/ErrorResponse.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package co.com.nelumbo.backpmo.infrastructure.exception;
+
+import java.time.LocalDateTime;
+
+public class ErrorResponse {
+    private String message;
+    private LocalDateTime timestamp;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+}

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/exception/GlobalExceptionHandler.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package co.com.nelumbo.backpmo.infrastructure.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+        ErrorResponse error = new ErrorResponse(ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+}

--- a/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/exception/NotFoundException.java
+++ b/infrastructure/src/main/java/co/com/nelumbo/backpmo/infrastructure/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package co.com.nelumbo.backpmo.infrastructure.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- add `NotFoundException`, `ErrorResponse`, and `GlobalExceptionHandler`
- throw `NotFoundException` from `ProjectController#getProjectById`

## Testing
- `./gradlew test` *(fails: Execution failed for task ':app-service:test')*

------
https://chatgpt.com/codex/tasks/task_e_686d96ccfe40832a994336d6beb76989